### PR TITLE
Rebuild oniguruma 6.9.7.1 for aarch64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  #trigger 1
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=oniguruma 
     - {{ pin_subpackage('oniguruma', max_pin='x.x') }}


### PR DESCRIPTION
`jq` requires it on aarch64 https://github.com/AnacondaRecipes/jq-feedstock/pull/1