### PR TITLE
oniguruma 6.9.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.9.7.1" %}
+{% set version = "6.9.8" %}
 
 package:
   name: oniguruma
@@ -7,7 +7,7 @@ package:
 source:
   fn: onig-{{ version }}.tar.gz
   url: https://github.com/kkos/oniguruma/releases/download/v{{ version }}/onig-{{ version }}.tar.gz
-  sha256: 6444204b9c34e6eb6c0b23021ce89a0370dad2b2f5c00cd44c342753e0b204d9
+  sha256: 28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index d4cf87a..b04e599 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.9.7.1" %}
+{% set version = "6.9.8" %}
 
 package:
   name: oniguruma
@@ -7,7 +7,7 @@ package:
 source:
   fn: onig-{{ version }}.tar.gz
   url: https://github.com/kkos/oniguruma/releases/download/v{{ version }}/onig-{{ version }}.tar.gz
-  sha256: 6444204b9c34e6eb6c0b23021ce89a0370dad2b2f5c00cd44c342753e0b204d9
+  sha256: 28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 
**_Notes:_**
 * 
**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 6.9.8
 * Popularity: 
    * 3 months downloads: 114030.0
    * All time:  2253945 downloads -  oniguruma  6.9.8  A regular expression library.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/kkos/oniguruma/tree/v6.9.8 exists
2. - [x] https://github.com/kkos/oniguruma is present
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/kkos/oniguruma/tree/v6.9.8
    200
5. - [ ] Additional research
    https://github.com/kkos/oniguruma/issues
    200
6. - [x] `dev_url` is present
    https://github.com/kkos/oniguruma
7. - [ ] `doc_url` error:
    
    
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific` or `Noarch`
14. - [ ] Verify that private module are not mentioned on the recipe For example: (_private_module)
15.  - [x] license_file: COPYING is present
16. - [x] License: BSD-2-Clause
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |

17. - [ ] License family is NOT present
    
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/oniguruma-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/oniguruma-feedstock/tree/6.9.8)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/oniguruma)
* [Diff between upstream and feature branch](https://github.com/conda-forge/oniguruma-feedstock/compare/main...AnacondaRecipes:6.9.8)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/oniguruma-feedstock/compare/master...AnacondaRecipes:6.9.8)
* [The last merged PRs](https://github.com/AnacondaRecipes/oniguruma-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 6.9.8 git@github.com:AnacondaRecipes/oniguruma-feedstock.git
```
